### PR TITLE
Improve structure and docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024 Mykola C.
+
+Permission is granted to use this software for personal, non-commercial purposes only.
+
+Commercial use, redistribution, or modification of this code or its derivative works is prohibited without prior written consent from the copyright holder. The author retains exclusive ownership of both the backend and the proprietary frontend associated with this project.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# AI Support Platform Backend
+
+This repository contains the backend component for an AI assistant web application powered by **FastAPI**, **PostgreSQL**, and the **OpenAI Assistants API**. It exposes a simple HTTP API and minimal HTML page demonstrating chat capabilities.
+
+## Tech Stack
+
+- **Python 3.12**
+- **FastAPI** – async web framework
+- **SQLAlchemy** – async ORM for PostgreSQL
+- **OpenAI Python SDK** – integration with the Assistants API
+
+## Setup
+
+1. Ensure Python 3.12+ and PostgreSQL are installed.
+2. Install dependencies via [Poetry](https://python-poetry.org/):
+   ```bash
+   poetry install
+   ```
+3. Copy `.env.example` to `.env` and fill in your configuration:
+   - `OPENAI_API_KEY`
+   - `OPENAI_ASSISTANT_ID`
+   - `POSTGRES_URL`
+4. Start the application:
+   ```bash
+   poetry run uvicorn app.main:app --reload
+   ```
+
+## Usage
+
+The service assigns each visitor a unique `user_id` cookie. All chat history is stored in OpenAI threads associated with this identifier. When you open `/` in a browser, a basic chat interface allows you to send messages. Requests to `/api/v1/chat` forward your message to the OpenAI Assistant and return the latest reply.
+
+## Frontend
+
+**Important:** The production frontend of this project is proprietary and not included in this repository. It is available upon request.
+
+## License
+
+See [LICENSE](LICENSE) for license details.

--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -1,6 +1,8 @@
+"""API endpoints for chat interactions."""
+
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,10 +15,14 @@ router = APIRouter()
 
 
 class ChatRequest(BaseModel):
+    """Payload for chat requests."""
+
     message: str
 
 
 async def get_async_session() -> AsyncSession:
+    """FastAPI dependency that yields an async DB session."""
+
     async with async_session() as session:
         yield session
 
@@ -27,6 +33,8 @@ async def chat_with_bot(
     request: Request,
     db: AsyncSession = Depends(get_async_session),
 ):
+    """Send a message to the assistant and return the response."""
+
     user_id = request.cookies.get("user_id")
     if not user_id:
         raise HTTPException(status_code=400, detail="Missing user_id in cookie")

--- a/app/config.py
+++ b/app/config.py
@@ -1,11 +1,17 @@
+"""Application configuration loaded from environment variables."""
+
 from pydantic_settings import BaseSettings
 
+
 class Settings(BaseSettings):
+    """Typed settings for the application."""
+
     openai_api_key: str
     postgres_url: str
     openai_assistant_id: str
 
     class Config:
         env_file = ".env"
+
 
 settings = Settings()

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -1,6 +1,10 @@
-from app.db.session import engine, Base
-from app.db import models
+"""Database initialization utilities."""
 
-async def init_db():
+from app.db import models
+from app.db.session import Base, engine
+
+async def init_db() -> None:
+    """Create database tables if they do not exist."""
+
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)

--- a/app/db/models/dialog.py
+++ b/app/db/models/dialog.py
@@ -1,4 +1,5 @@
-# Будет использоваться позже (GPT-ответы, сообщения и т.д.)
+"""Placeholder ORM model for future dialog storage."""
+
 from sqlalchemy.orm import DeclarativeBase
 
 class Placeholder:

--- a/app/db/models/user_session.py
+++ b/app/db/models/user_session.py
@@ -1,13 +1,18 @@
-from sqlalchemy import Column, String, DateTime, func
+"""ORM model for user chat sessions."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
-from datetime import datetime
-import uuid
 
 from app.db.session import Base
 
 
 class UserSession(Base):
+    """Database table tracking user conversations."""
+
     __tablename__ = "user_sessions"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,5 +1,8 @@
+"""Database engine and session management."""
+
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
+
 from app.config import settings
 
 

--- a/app/external/openai.py
+++ b/app/external/openai.py
@@ -1,67 +1,81 @@
+"""Utility functions for interacting with the OpenAI Assistants API."""
+
+from __future__ import annotations
+
 import asyncio
 import logging
 from typing import Optional
 
-import openai
 from openai import AsyncOpenAI
 from openai.types.beta import Thread
 from openai.types.beta.threads import Run
 
 from app.config import settings
 
-# Настраиваем клиента
+# Configure the OpenAI async client once and reuse it
 client = AsyncOpenAI(api_key=settings.openai_api_key)
 
 logger = logging.getLogger(__name__)
 
 ASSISTANT_ID: str = settings.openai_assistant_id
 
+# Poll interval while waiting for assistant run completion
+_POLL_INTERVAL: float = 0.25
+_MAX_POLLS: int = 120  # 30 seconds
+
 
 async def create_thread() -> str:
-    """Создаёт новый thread и возвращает его ID"""
+    """Create a new assistant thread and return its ID."""
+
     thread: Thread = await client.beta.threads.create()
     return thread.id
 
 
+async def _wait_for_run_completion(run: Run, thread_id: str) -> Run:
+    """Poll the run status until completion or timeout."""
+
+    for _ in range(_MAX_POLLS):
+        run_status: Run = await client.beta.threads.runs.retrieve(
+            thread_id=thread_id,
+            run_id=run.id,
+        )
+        if run_status.status == "completed":
+            return run_status
+        if run_status.status == "failed":
+            raise RuntimeError("Assistant run failed")
+        await asyncio.sleep(_POLL_INTERVAL)
+
+    raise TimeoutError("Assistant run timed out")
+
+
 async def ask_gpt_with_memory(message: str, thread_id: str) -> str:
-    """Отправляет сообщение в thread, запускает run и возвращает ответ от ассистента"""
+    """Send a message to the assistant and return the response."""
+
     try:
-        # 1. Добавляем сообщение от пользователя
         await client.beta.threads.messages.create(
             thread_id=thread_id,
             role="user",
             content=message,
         )
 
-    # 2. Запускаем run ассистента
         run: Run = await client.beta.threads.runs.create(
             thread_id=thread_id,
             assistant_id=ASSISTANT_ID,
         )
 
-    # 3. Ожидаем завершения run
-        for _ in range(60):  # максимум 30 секунд
-            run_status: Run = await client.beta.threads.runs.retrieve(
-                thread_id=thread_id,
-                run_id=run.id,
-            )
-            if run_status.status == "completed":
-                break
-            elif run_status.status == "failed":
-                raise RuntimeError("Assistant run failed")
-            await asyncio.sleep(0.5)
-        else:
-            raise TimeoutError("Assistant run timed out")
+        await _wait_for_run_completion(run, thread_id)
 
-        # 4. Получаем последнее сообщение от ассистента
-        messages = await client.beta.threads.messages.list(thread_id=thread_id)
-        for msg in messages.data:  # API returns latest first
+        messages = await client.beta.threads.messages.list(
+            thread_id=thread_id,
+            limit=1,
+        )
+        for msg in messages.data:
             if msg.role == "assistant" and msg.content:
                 response = msg.content[0].text.value
                 logger.debug("Assistant response: %s", response)
                 return response
 
         return "[No response from assistant]"
-    except Exception as e:
-        logger.exception("OpenAI assistant request failed: %s", e)
+    except Exception as exc:
+        logger.exception("OpenAI assistant request failed: %s", exc)
         raise

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,7 @@
-from fastapi import FastAPI
+"""FastAPI application entry point."""
+
 from contextlib import asynccontextmanager
+from fastapi import FastAPI
 
 from app.api.v1 import chat
 from app.db.init_db import init_db
@@ -10,6 +12,8 @@ API_PREFIX = "/api/v1"
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    """Initialize resources on startup."""
+
     await init_db()
     yield
 

--- a/app/middleware/cookies.py
+++ b/app/middleware/cookies.py
@@ -1,13 +1,18 @@
+"""Middleware for managing user identification cookies."""
+
+from uuid import uuid4
+
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
-from uuid import uuid4
 
 from app.db.session import async_session
 from app.models.user_session import UserSessionCreate
 from app.services.user_session import UserSessionService
 
 class UserIDCookieMiddleware(BaseHTTPMiddleware):
+    """Ensure each visitor has a unique ``user_id`` cookie."""
+
     async def dispatch(self, request: Request, call_next):
         user_id = request.cookies.get("user_id")
 

--- a/app/models/dialog.py
+++ b/app/models/dialog.py
@@ -1,3 +1,5 @@
+"""Pydantic models for dialog payloads."""
+
 from pydantic import BaseModel, Field
 
 

--- a/app/models/user_session.py
+++ b/app/models/user_session.py
@@ -1,7 +1,10 @@
-from pydantic import BaseModel
-from uuid import UUID
+"""Pydantic models for user session data transfer objects."""
+
 from datetime import datetime
-from typing import Optional, Literal
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
 
 
 class UserSessionCreate(BaseModel):

--- a/app/services/user_session.py
+++ b/app/services/user_session.py
@@ -1,13 +1,18 @@
+"""Business logic for managing user chat sessions."""
+
 from datetime import datetime
 from uuid import UUID, uuid4
-from sqlalchemy.ext.asyncio import AsyncSession
+
 from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.user_session import UserSession
 from app.models.user_session import UserSessionCreate
 
 
 class UserSessionService:
+    """Service layer for ``UserSession`` database operations."""
+
     @staticmethod
     async def create_session(db: AsyncSession, data: UserSessionCreate) -> UserSession:
         session = UserSession(

--- a/app/web/pages.py
+++ b/app/web/pages.py
@@ -1,14 +1,18 @@
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
-from fastapi.templating import Jinja2Templates
+"""Routes serving HTML pages."""
 
 import os
 from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 
 router = APIRouter()
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=os.path.join(BASE_DIR, "templates"))
 
 @router.get("/", response_class=HTMLResponse)
-async def chat_page(request: Request):
+async def chat_page(request: Request) -> HTMLResponse:
+    """Render the chat page template."""
+
     return templates.TemplateResponse("chat.html", {"request": request})


### PR DESCRIPTION
## Summary
- refactor OpenAI helper for clearer logic and faster polling
- clean up middleware and API routes with type hints and docstrings
- document database and config modules
- provide README and custom LICENSE

## Testing
- `pytest -q`
- `python -m compileall -q app`


------
https://chatgpt.com/codex/tasks/task_e_685275b08ec0832885c59d94284383c4